### PR TITLE
Fix all_hosts_static.erb template, avoid breaking if static_hosts is not an array (ie. undef).

### DIFF
--- a/templates/all_hosts_static.erb
+++ b/templates/all_hosts_static.erb
@@ -1,4 +1,6 @@
 <% static_hosts = scope.lookupvar('check_mk::config::all_hosts_static') -%>
+<% if static_hosts.is_a? Array -%>
 <% static_hosts.each do |check_host| -%>
   '<%= host_name %>',
+<% end -%>
 <% end -%>


### PR DESCRIPTION
If check_mk::config::all_hosts_static is not set the template breaks on doing .each, so ensure that we have an array.
