### PR TITLE
check_mk::agent::install: fix install from files on debian. 

### DIFF
--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -8,11 +8,13 @@ class check_mk::agent (
   $user         = 'root',
   $version      = undef,
   $workspace    = '/root/check_mk',
+  $provider     = 'rpm',
 ) {
   class { 'check_mk::agent::install':
     version   => $version,
     filestore => $filestore,
     workspace => $workspace,
+    provider  => $provider,
   }
   class { 'check_mk::agent::config':
     ip_whitelist => $ip_whitelist,

--- a/manifests/agent/install.pp
+++ b/manifests/agent/install.pp
@@ -18,6 +18,9 @@ class check_mk::agent::install (
     if $provider == 'rpm' {
       $pkg_suffix = '${pkg_suffix}'
     } elsif $provider == 'dpkg' {
+      notify { 'Make sure you have renamed the deb packages in order to match redhat naming conventions (see source).':
+        loglevel => warning,
+      }
       $pkg_suffix = '_all.deb'
     } else {
       notify { 'Provider not recognized':}


### PR DESCRIPTION
Added dpkg support. It's however still required to rename the deb file to match redhat naming conventions (see warning).
